### PR TITLE
Only run CI on master

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,8 +1,8 @@
 name: Dev
 on:
   push:
-    branches-ignore:
-      - "dependabot/**"
+    branches:
+    - master
   pull_request:
 jobs:
   all:


### PR DESCRIPTION
This avoids duplicate CI runs when a branch is pushed and turned into a PR.